### PR TITLE
Automatic Docker compose setup for development and evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,42 @@ Guacamole and Keycloak:
 cp env-template .env
 # read the .env file thoroughly and modify it properly
 docker-compose up -d
-# set up Keycloak
-# modify the .env file
-docker-compose up -d
 ```
 
-Currently, Keycloak has to be set up manually. The admin/admin user can be
-used for that purpose. Any valid realm may be created and its details put
-in the ``.env`` file afterwards with a final run of docker-compose to get
-Bumblebee working with it. Both Bumblebee and Guacamole need their own
-clients set up in Keycloak to work with it.
+Currently, a Keycloak instance is set up automatically to provide the following
+default users for testing all user roles supported by Bumblebee:
+
+  - Test user for the `admin` role:
+    * Username: admin
+    * Password: admin
+  - Test user for the `coreservices` role:
+    * Username: coreservices
+    * Password: coreservices
+  - Test user for the `staff` role:
+    * Username: staff
+    * Password: staff
+  - Test user for the `user` role:
+    * Username: user
+    * Password: user
+
+The Keycloak instance can be accessed with the admin/admin user to configure
+further OpenID Connect settings if needed. Both Bumblebee and Guacamole need
+their own OpenID Connect client endpoints to request authentication of a user.
+Therefore, the Keycloak instance provides two OpenID Connect clients
+configured properly.
+
+A successful docker-compose test setup with a proper authentication only works
+if your Docker host machine can resolve the names of all Docker services. The
+name resolution can be implemented by using a DNS proxy server or by adding the
+following line to the `/etc/hosts` file of the Docker host machine:
+
+```
+127.0.0.1  bumblebee rqscheduler rqworker mariadb redis guacd guacamole keycloak
+```
+
+Then you can access the running Bumblebee service from your Docker host machine
+under the following URL:
+
+```
+http://bumblebee:8000
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       DEBUG: "True"
 
       DB_HOST: mariadb
-      DB_USER: root
-      DB_PASSWORD: toor
+      DB_USER: ${DB_USER:-root}
+      DB_PASSWORD: ${DB_PASSWORD:-toor}
 
       REDIS_HOST: redis
     env_file:
@@ -77,7 +77,7 @@ services:
   mariadb:
     image: mariadb
     environment:
-      MARIADB_ROOT_PASSWORD: toor
+      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD:-toor}
     ports:
     - 3306:3306
     volumes:
@@ -109,8 +109,8 @@ services:
       # Guacamole has to share the database with Bumblebee.
       MYSQL_HOSTNAME: mariadb
       MYSQL_DATABASE: bumblebee
-      MYSQL_USER: root
-      MYSQL_PASSWORD: toor
+      MYSQL_USER: ${DB_USER:-root}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-toor}
 
     env_file:
       - .env
@@ -125,10 +125,10 @@ services:
     environment:
       KC_DB: mariadb
       KC_DB_URL: jdbc:mariadb://mariadb/keycloak
-      KC_DB_USERNAME: root
-      KC_DB_PASSWORD: toor
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB_USERNAME: ${DB_USER:-root}
+      KC_DB_PASSWORD: ${DB_PASSWORD:-toor}
+      KEYCLOAK_ADMIN: ${KC_USER:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KC_PASSWORD:-admin}
     ports:
       - 8080:8080
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     environment:
       <<: *bb_env
       DJANGO_MIGRATE: "True"
+    env_file:
+      - .env
     volumes:
       - .:/app
     restart: on-failure
@@ -174,13 +176,17 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
+    volumes:
+      - ./initkc:/opt/keycloak/data/import
+      - kcdata:/opt/keycloak/data
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/realms/master"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/realms/bumblebee"]
       interval: 10s
       retries: 9
       start_period: 5s
-    command: start-dev
+    command: start-dev --import-realm
 
 volumes:
   dbdata:
+  kcdata:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       start_period: 5s
 
   guacd:
-    image: guacamole/guacd:1.3.0
+    image: guacamole/guacd
     restart: unless-stopped
     ports:
       - 4822:4822
@@ -133,7 +133,7 @@ services:
       start_period: 5s
 
   guacamole:
-    image: guacamole/guacamole:1.3.0
+    image: guacamole/guacamole
     restart: unless-stopped
     environment:
 
@@ -161,7 +161,7 @@ services:
         condition: service_healthy
 
   keycloak:
-    image: quay.io/keycloak/keycloak:18.0.2
+    image: quay.io/keycloak/keycloak
     environment:
       KC_DB: mariadb
       KC_DB_URL: jdbc:mariadb://mariadb/keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,13 @@ services:
       mariadb:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+      guacamole:
+        condition: service_healthy
     links:
     - mariadb:mariadb
     - redis:redis
@@ -58,7 +64,9 @@ services:
       mariadb:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
     links:
     - mariadb:mariadb
     - redis:redis
@@ -79,7 +87,9 @@ services:
       mariadb:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
     volumes:
     - .:/app
 
@@ -94,6 +104,9 @@ services:
     - ./initdb:/docker-entrypoint-initdb.d
     healthcheck:
       test: [ "CMD", "mysqladmin", "--user=${DB_USER:-root}", "--password=${DB_PASSWORD:-toor}", "ping", "--silent" ]
+      interval: 10s
+      retries: 9
+      start_period: 5s
 
   redis:
     image: redis:alpine
@@ -101,12 +114,22 @@ services:
     - 6379:6379
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      retries: 9
+      start_period: 5s
 
   guacd:
     image: guacamole/guacd:1.3.0
     restart: unless-stopped
     ports:
     - 4822:4822
+    healthcheck:
+      # Use healthcheck command from guacd Dockerfile
+      interval: 10s
+      retries: 9
+      start_period: 5s
 
   guacamole:
     image: guacamole/guacamole:1.3.0
@@ -125,11 +148,16 @@ services:
       - .env
     ports:
     - 9000:8080
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:8080/guacamole" ]
+      interval: 10s
+      retries: 9
+      start_period: 5s
     depends_on:
       mariadb:
         condition: service_healthy
       guacd:
-        condition: service_started
+        condition: service_healthy
 
   keycloak:
     image: quay.io/keycloak/keycloak:18.0.2
@@ -145,6 +173,11 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:8080/realms/master" ]
+      interval: 10s
+      retries: 9
+      start_period: 5s
     command: start-dev
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
     restart: unless-stopped
     command: django-admin runserver 0.0.0.0:8000
     depends_on:
-    - mariadb
-    - redis
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
     - mariadb:mariadb
     - redis:redis
@@ -40,6 +42,9 @@ services:
     volumes:
     - .:/app
     restart: on-failure
+    depends_on:
+      mariadb:
+        condition: service_healthy
     command: /docker-setup.sh
 
   rqscheduler:
@@ -50,8 +55,10 @@ services:
     restart: on-failure
     command: django-admin rqscheduler -i5
     depends_on:
-    - mariadb
-    - redis
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
     - mariadb:mariadb
     - redis:redis
@@ -69,8 +76,10 @@ services:
     restart: on-failure
     command: django-admin rqworker
     depends_on:
-    - mariadb
-    - redis
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
     - .:/app
 
@@ -84,7 +93,7 @@ services:
     - dbdata:/var/lib/mysql
     - ./initdb:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      test: [ "CMD", "mysqladmin", "--user=${DB_USER:-root}", "--password=${DB_PASSWORD:-toor}", "ping", "--silent" ]
 
   redis:
     image: redis:alpine
@@ -117,8 +126,10 @@ services:
     ports:
     - 9000:8080
     depends_on:
-    - mariadb
-    - guacd
+      mariadb:
+        condition: service_healthy
+      guacd:
+        condition: service_started
 
   keycloak:
     image: quay.io/keycloak/keycloak:18.0.2
@@ -132,7 +143,8 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
     command: start-dev
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     stdin_open: true
     tty: true
     ports:
-    - 8000:8000
+      - 8000:8000
     environment: &bb_env
       DEBUG: "True"
 
@@ -19,7 +19,7 @@ services:
     env_file:
       - .env
     volumes:
-    - .:/app
+      - .:/app
     restart: unless-stopped
     command: django-admin runserver 0.0.0.0:8000
     depends_on:
@@ -34,19 +34,19 @@ services:
       guacamole:
         condition: service_healthy
     links:
-    - mariadb:mariadb
-    - redis:redis
+      - mariadb:mariadb
+      - redis:redis
 
   init:
     build: .
     links:
-    - mariadb:mariadb
-    - redis:redis
+      - mariadb:mariadb
+      - redis:redis
     environment:
       <<: *bb_env
       DJANGO_MIGRATE: "True"
     volumes:
-    - .:/app
+      - .:/app
     restart: on-failure
     depends_on:
       mariadb:
@@ -68,19 +68,19 @@ services:
       init:
         condition: service_completed_successfully
     links:
-    - mariadb:mariadb
-    - redis:redis
+      - mariadb:mariadb
+      - redis:redis
     volumes:
-    - .:/app
+      - .:/app
 
   rqworker:
     build: .
     links:
-    - mariadb:mariadb
-    - redis:redis
+      - mariadb:mariadb
+      - redis:redis
     environment: *bb_env
     env_file:
-    - .env
+      - .env
     restart: on-failure
     command: django-admin rqworker
     depends_on:
@@ -91,19 +91,20 @@ services:
       init:
         condition: service_completed_successfully
     volumes:
-    - .:/app
+      - .:/app
 
   mariadb:
     image: mariadb
     environment:
       MARIADB_ROOT_PASSWORD: ${DB_PASSWORD:-toor}
     ports:
-    - 3306:3306
+      - 3306:3306
     volumes:
-    - dbdata:/var/lib/mysql
-    - ./initdb:/docker-entrypoint-initdb.d
+      - dbdata:/var/lib/mysql
+      - ./initdb:/docker-entrypoint-initdb.d
     healthcheck:
-      test: [ "CMD", "mysqladmin", "--user=${DB_USER:-root}", "--password=${DB_PASSWORD:-toor}", "ping", "--silent" ]
+      test: ["CMD", "mysqladmin", "--user=${DB_USER:-root}",
+             "--password=${DB_PASSWORD:-toor}", "ping", "--silent"]
       interval: 10s
       retries: 9
       start_period: 5s
@@ -111,11 +112,11 @@ services:
   redis:
     image: redis:alpine
     ports:
-    - 6379:6379
+      - 6379:6379
     volumes:
       - redis_data:/data
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       retries: 9
       start_period: 5s
@@ -124,7 +125,7 @@ services:
     image: guacamole/guacd:1.3.0
     restart: unless-stopped
     ports:
-    - 4822:4822
+      - 4822:4822
     healthcheck:
       # Use healthcheck command from guacd Dockerfile
       interval: 10s
@@ -147,9 +148,9 @@ services:
     env_file:
       - .env
     ports:
-    - 9000:8080
+      - 9000:8080
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "http://localhost:8080/guacamole" ]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/guacamole"]
       interval: 10s
       retries: 9
       start_period: 5s
@@ -174,7 +175,7 @@ services:
       mariadb:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "http://localhost:8080/realms/master" ]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/realms/master"]
       interval: 10s
       retries: 9
       start_period: 5s

--- a/env-template
+++ b/env-template
@@ -4,14 +4,14 @@
 REQUIRE_AAF=False
 
 # Friendly name for the current environment.
-ENVIRONMENT_NAME=
+ENVIRONMENT_NAME=Bumblebee
 
 # Names/addresses under which Bumblebee is accessible. Comma-separated.
-ALLOWED_HOSTS=
+ALLOWED_HOSTS=localhost,bumblebee
 
 # Full URL to the entry point to Bumblebee.
 # https SITE_URL assumes there is a proxy in front
-SITE_URL=
+SITE_URL=http://bumblebee:8000
 
 ### Bumblebee credentials
 
@@ -32,11 +32,11 @@ SITE_URL=
 #   zone=self.boot_volume.zone.lower()
 #   path=guac_utils.get_connection_path(self.guac_connection)
 # e.g. GUACAMOLE_URL_TEMPLATE=http://{env}-guacamole-{zone}.example.com/{path}
-GUACAMOLE_URL_TEMPLATE=
+GUACAMOLE_URL_TEMPLATE=http://guacamole:9000/guacamole/{path}
 
 ### Bumblebee OpenID Connect integration config
 
-OIDC_SERVER_URL=
+OIDC_SERVER_URL=http://keycloak:8080/realms/bumblebee/protocol/openid-connect
 
 OIDC_RP_CLIENT_ID=bumblebee
 OIDC_RP_CLIENT_SECRET=
@@ -58,8 +58,8 @@ OS_KEYNAME=bumblebee
 ### Guacamole OpenID Connect integration config
 
 # Guacamole requires a non-confidential OIDC client with implicit flow enabled.
-OPENID_AUTHORIZATION_ENDPOINT=
-OPENID_JWKS_ENDPOINT=
-OPENID_ISSUER=
+OPENID_AUTHORIZATION_ENDPOINT=http://keycloak:8080/realms/bumblebee/protocol/openid-connect/auth
+OPENID_JWKS_ENDPOINT=http://keycloak:8080/realms/bumblebee/protocol/openid-connect/certs
+OPENID_ISSUER=http://keycloak:8080/realms/bumblebee
 OPENID_CLIENT_ID=guacamole
-OPENID_REDIRECT_URI=
+OPENID_REDIRECT_URI=http://guacamole:9000/guacamole

--- a/env-template
+++ b/env-template
@@ -13,6 +13,18 @@ ALLOWED_HOSTS=
 # https SITE_URL assumes there is a proxy in front
 SITE_URL=
 
+### Bumblebee credentials
+
+# If no database credentials are set, the username 'root' and the password
+# 'toor' are used as defaults.
+#DB_USER=
+#DB_PASSWORD=
+
+# If no keycloak credentials are set, the username 'admin' and the password
+# 'admin' are used as defaults.
+#KC_USER=
+#KC_PASSWORD=
+
 ### Bumblebee Guacamole integration config
 
 # GUACAMOLE_URL_TEMPLATE uses three variables on templating:

--- a/initdb/01.sql
+++ b/initdb/01.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE `bumblebee`;
-CREATE DATABASE `keycloak`;

--- a/initdb/bumblebee.sql
+++ b/initdb/bumblebee.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS `bumblebee`;

--- a/initdb/keycloak.sql
+++ b/initdb/keycloak.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS `keycloak`;

--- a/initkc/bumblebee-realm.json
+++ b/initkc/bumblebee-realm.json
@@ -1,0 +1,627 @@
+{
+  "realm" : "bumblebee",
+  "displayName" : "Bumblebee",
+  "displayNameHtml" : "<div class=\"kc-logo-text\"><span>Bumblebee</span></div>",
+  "enabled" : true,
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : false,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "roles" : {
+    "realm" : [ {
+      "name" : "admin",
+      "description" : "${role_admin}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "coreservices" ]
+      },
+      "clientRole" : false
+    }, {
+      "name" : "staff",
+      "description" : "${role_staff}",
+      "composite" : false,
+      "clientRole" : false
+    }, {
+      "name" : "user",
+      "description" : "${role_user}",
+      "composite" : false,
+      "clientRole" : false
+    }, {
+      "name" : "coreservices",
+      "description" : "${role_coreservices}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "staff" ]
+      },
+      "clientRole" : false
+    } ],
+    "client" : {
+      "bumblebee" : [ {
+        "name" : "access-bumblebee",
+        "description" : "${role_access-bumblebee}",
+        "composite" : false,
+        "clientRole" : true
+      } ],
+      "guacamole" : [ {
+        "name" : "access-guacamole",
+        "description" : "${role_access-guacamole}",
+        "composite" : false,
+        "clientRole" : true
+      } ]
+    }
+  },
+  "defaultRole" : {
+    "name" : "default-roles-bumblebee",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false
+  },
+  "requiredCredentials" : [ "password" ],
+  "clients" : [ {
+    "clientId" : "bumblebee",
+    "name" : "${client_bumblebee}",
+    "rootUrl" : "http://bumblebee:8000",
+    "adminUrl" : "http://bumblebee:8000/rcsadmin",
+    "baseUrl" : "/",
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "+" ],
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    }
+  }, {
+    "clientId" : "guacamole",
+    "name" : "${client_guacamole}",
+    "rootUrl" : "http://guacamole:9000",
+    "adminUrl" : "http://guacamole:9000/guacamole",
+    "baseUrl" : "/guacamole",
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/guacamole/*" ],
+    "webOrigins" : [ "+" ],
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : true,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    }
+  } ],
+  "clientScopes" : [ {
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "4052a400-3346-4e15-87d6-e057b4f8fa27",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false
+    } ]
+  }, {
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "roles",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "email", "role_list", "roles", "acr", "web-origins", "profile" ],
+  "defaultOptionalClientScopes" : [ "address", "offline_access", "phone", "microprofile-jwt" ],
+  "groups" : [ {
+    "name" : "bumblebee",
+    "path" : "/bumblebee",
+    "attributes" : { },
+    "realmRoles" : [ "user" ],
+    "clientRoles" : {
+      "bumblebee" : [ "access-bumblebee" ],
+      "guacamole" : [ "access-guacamole" ]
+    },
+    "subGroups" : [ {
+      "name" : "coreservices",
+      "path" : "/bumblebee/coreservices",
+      "attributes" : { },
+      "realmRoles" : [ "coreservices" ],
+      "clientRoles" : { },
+      "subGroups" : [ ]
+    }, {
+      "name" : "staff",
+      "path" : "/bumblebee/staff",
+      "attributes" : { },
+      "realmRoles" : [ "staff" ],
+      "clientRoles" : { },
+      "subGroups" : [ ]
+    }, {
+      "name" : "admin",
+      "path" : "/bumblebee/admin",
+      "attributes" : { },
+      "realmRoles" : [ "admin" ],
+      "clientRoles" : { },
+      "subGroups" : [ ]
+    } ]
+  } ],
+  "defaultGroups" : [ "/bumblebee" ],
+  "users" : [ {
+    "createdTimestamp" : 1665047553457,
+    "username" : "admin",
+    "enabled" : true,
+    "emailVerified" : true,
+    "firstName" : "Brian",
+    "lastName" : "Morales",
+    "email" : "brian.morales@bumblebee.test",
+    "credentials" : [ {
+      "type" : "password",
+      "value" : "admin"
+    } ],
+    "realmRoles" : [ "default-roles-bumblebee" ],
+    "groups" : [ "/bumblebee/admin" ]
+  }, {
+    "createdTimestamp" : 1665047553459,
+    "username" : "coreservices",
+    "enabled" : true,
+    "emailVerified" : true,
+    "firstName" : "Kelly",
+    "lastName" : "Adams",
+    "email" : "kelly.adams@bumblebee.test",
+    "credentials" : [ {
+      "type" : "password",
+      "value" : "coreservices"
+    } ],
+    "realmRoles" : [ "default-roles-bumblebee" ],
+    "groups" : [ "/bumblebee/coreservices" ]
+  }, {
+    "createdTimestamp" : 1665047553461,
+    "username" : "staff",
+    "enabled" : true,
+    "emailVerified" : true,
+    "firstName" : "Leroy",
+    "lastName" : "Hicks",
+    "email" : "leroy.hicks@bumblebee.test",
+    "credentials" : [ {
+      "type" : "password",
+      "value" : "staff"
+    } ],
+    "realmRoles" : [ "default-roles-bumblebee" ],
+    "groups" : [ "/bumblebee/staff" ]
+  }, {
+    "createdTimestamp" : 1665047553463,
+    "username" : "user",
+    "enabled" : true,
+    "emailVerified" : true,
+    "firstName" : "Miranda",
+    "lastName" : "Crawford",
+    "email" : "miranda.crawford@bumblebee.test",
+    "credentials" : [ {
+      "type" : "password",
+      "value" : "user"
+    } ],
+    "realmRoles" : [ "default-roles-bumblebee" ],
+    "groups" : [ "/bumblebee" ]
+  } ],
+  "keycloakVersion" : "19.0.2"
+}

--- a/researcher_workspace/settings.py
+++ b/researcher_workspace/settings.py
@@ -8,6 +8,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
+from ast import literal_eval
+
 import logging
 import os
 
@@ -30,6 +32,10 @@ def get_setting(setting, default=None, required=False):
     if required and not value:
         logger.info('Setting value for %s not found!', setting)
     return value
+
+def strtodictorlist(str):
+    dictlist = literal_eval(str)
+    return dictlist
 
 NAME = 'ARDC Nectar Virtual Desktop'
 
@@ -289,8 +295,8 @@ AUTO_APPROVE_WORKSPACES = bool(strtobool(
 # is approved.  (A list of the Feature 'app_name' values.)
 PROJECT_DEFAULT_FEATURES = ['researcher_desktop']
 
-DESKTOP_TYPES = get_setting('DESKTOP_TYPES')
-ZONES = get_setting('ZONES')
+DESKTOP_TYPES = strtodictorlist(get_setting('DESKTOP_TYPES', '[]'))
+ZONES = strtodictorlist(get_setting('ZONES', '[]'))
 
 GENERAL_WARNING_MESSAGE = get_setting('GENERAL_WARNING_MESSAGE')
 # Friendly name for the current environment.


### PR DESCRIPTION
These changes improve the Docker compose setup for development and evaluation purposes. Among other things, credentials are made configurable, Docker healthchecks are carried out for all Docker services to fix the service startup order and Keycloak is set up automatically. The Keycloak setup provides the 'bumblebee' realm with test users and groups for all used OpenID Connect clients, namely the Bumblebee and Guacamole client.